### PR TITLE
Add custom FileProvider

### DIFF
--- a/cropper/src/main/AndroidManifest.xml
+++ b/cropper/src/main/AndroidManifest.xml
@@ -1,4 +1,14 @@
-<manifest
-    package="com.theartofdev.edmodo.cropper">
-
+<manifest package="com.theartofdev.edmodo.cropper"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <provider
+            android:name=".ImageCropperFileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths"/>
+        </provider>
+    </application>
 </manifest>

--- a/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImage.java
+++ b/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImage.java
@@ -44,6 +44,7 @@ import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
+import androidx.core.content.FileProvider;
 import androidx.fragment.app.Fragment;
 
 /**
@@ -343,7 +344,8 @@ public final class CropImage {
     Uri outputFileUri = null;
     File getImage = context.getExternalCacheDir();
     if (getImage != null) {
-      outputFileUri = Uri.fromFile(new File(getImage.getPath(), "pickImageResult.jpeg"));
+      File pickImageFile = new File(getImage.getPath(), "pickImageResult.jpeg");
+      outputFileUri = FileProvider.getUriForFile(context, context.getPackageName() + ".fileprovider", pickImageFile);
     }
     return outputFileUri;
   }

--- a/cropper/src/main/java/com/theartofdev/edmodo/cropper/ImageCropperFileProvider.java
+++ b/cropper/src/main/java/com/theartofdev/edmodo/cropper/ImageCropperFileProvider.java
@@ -1,0 +1,10 @@
+package com.theartofdev.edmodo.cropper;
+
+import androidx.core.content.FileProvider;
+
+/**
+ * Dummy file provider
+ */
+public class ImageCropperFileProvider extends FileProvider
+{
+}

--- a/cropper/src/main/res/xml/provider_paths.xml
+++ b/cropper/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <external-cache-path name="external_cached_cropper_files" path="." />
+</paths>


### PR DESCRIPTION
This fixes https://github.com/ArthurHub/Android-Image-Cropper/issues/659, similar to https://github.com/expo/expo/issues/3706, where a FileUriExposedException is thrown when the Image Cropper attempts to access a file created by the Camera.
Fix is adapted from https://github.com/expo/expo/pull/3743.
A FileProvider is used to share the file securely using using a content:// uri.
A custom FileProvider is used rather than the default because of possible interactions when multiple authorities use the same FileProvider (https://stackoverflow.com/questions/43175014/possible-to-use-multiple-authorities-with-fileprovider)
